### PR TITLE
Fix issues with VSCode being unhappy about whitespace.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}


### PR DESCRIPTION
Just a workspace settings file which, at the moment, only has one setting, setting the tab size to make VSCode and prettier happy.